### PR TITLE
wip twigへの組み込み 新着情報管理 編集

### DIFF
--- a/src/Eccube/Resource/template/admin/Content/news_edit.twig
+++ b/src/Eccube/Resource/template/admin/Content/news_edit.twig
@@ -8,7 +8,7 @@ http://www.lockon.co.jp/
 For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 #}
-{% extends '@admin/old_frame.twig' %}
+{% extends '@admin/default_frame.twig' %}
 
 {% set menus = ['content', 'news'] %}
 
@@ -43,44 +43,58 @@ $(function() {
 {% endblock javascript %}
 
 {% block main %}
-    <div class="row" id="aside_wrap">
-        <div id="detail_wrap" class="col-md-9">
-            <div id="detail_box" class="box">
-                <div id="detail_box__header" class="box-header">
-                    <h3 class="box-title">{{'admin.content.news_edit.66'|trans}}</h3>
-                </div><!-- /.box-header -->
-                <form role="form" class="form-horizontal" name="form1" id="form1" method="post" action="?">
-                    <div id="detail_box__body" class="box-body">
-
-                        {{ form_row(form._token) }}
-
-                        <div id="detail_box__date" class="form-group">
-                            {{ form_label(form.publish_date) }}
-                            <div class="col-sm-10">
-                                {{ form_widget(form.publish_date, {'attr': {'class': 'input_cal'}}) }}
-                                {{ form_errors(form.publish_date) }}
-                            </div>
+    <div class="row m-0" id="aside_wrap">
+        <div id="detail_wrap" class="col-md-12">
+            <div id="detail_box" class="card rounded border-0 mb-4">
+                <div id="detail_box__header" class="card-header">
+                    <div class="row">
+                        <div class="col-8">
+                            <span class="card-title">{{'admin.content.news_edit.66'|trans}}</span>
                         </div>
+                        <div class="col-4 text-right">
+                            <a data-toggle="collapse" href="#ordererInfo" aria-expanded="false" aria-controls="ordererInfo">
+                                <i class="fa fa-angle-up fa-lg"></i>
+                            </a>
+                        </div>
+                    </div>
+                </div><!-- /.box-header -->
+                <div class="collapse show ec-cardCollapse" id="ordererInfo">
+                    <div class="card-body">
+                        <form role="form" class="form-horizontal" name="form1" id="form1" method="post" action="?">
+                            <div class="row mb-2">
+                                <div class="col-3">
+                                    <span></span>
+                                </div>
+                            </div>
+                              {{ form_row(form._token) }}
 
-                        {{ form_row(form.title) }}
+                                <div id="detail_box__date" class="form-group row">
+                                  {{ form_label(form.publish_date) }}
+                                    <div class="col-sm-10">
+                                      {{ form_widget(form.publish_date, {'attr': {'class': 'input_cal'}}) }}
+                                      {{ form_errors(form.publish_date) }}
+                                    </div>
+                                </div>
 
-                        {{ form_row(form.url) }}
+                              {{ form_row(form.title) }}
 
-                        {{ form_row(form.link_method) }}
+                              {{ form_row(form.url) }}
 
-                        {{ form_row(form.description) }}
+                              {{ form_row(form.link_method) }}
 
-                    </div><!-- /.box-body -->
-                </form>
-            </div><!-- /.box -->
+                              {{ form_row(form.description) }}
+                        </form>
+                    </div><!-- /.box -->
 
-            <div id="detail_box__footer" class="row">
-                <div id="detail_box__back_button" class="col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-3 text-center btn_area">
-                    <p><a href="{{ url('admin_content_news') }}">{{'admin.content.news_edit.67'|trans}}</a></p>
+                    <div id="detail_box__footer" class="row">
+                        <div id="detail_box__back_button" class="col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-3 text-center btn_area">
+                            <p><a href="{{ url('admin_content_news') }}">{{'admin.content.news_edit.67'|trans}}</a></p>
+                        </div>
+                    </div>
+
                 </div>
-            </div>
-
-        </div><!-- /.col -->
+                    </div>
+                </div>
 
         <div class="col-md-3" id="aside_column">
             <div id="common_box" class="col_inner">


### PR DESCRIPTION
issue EC-CUBE/Eccube-Styleguide-Admin#148

```
twig
{{ form_row(form.title) }}

html
<div class="form-group">
  <label class="col-sm-2 control-label required" for="admin_news_title">タイトル</label>
  <div class="col-sm-10">
    <input type="text" id="admin_news_title" name="admin_news[title]" required="required" class="form-control">
  </div>
</div>
```
- [ ] 現在上記のように、classは `form-group` だけなので `row` を付ける。

- [ ] モックで使用している `block conversionArea` をtwigへ組み込む。
